### PR TITLE
az-digital/az_quickstart#311: Alias main branch as '2.x-dev' for composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,5 +16,10 @@
   "type": "drupal-library",
   "require": {
       "composer/installers": "*"
+  },
+  "extra": {
+      "branch-alias": {
+          "dev-main": "2.x-dev"
+      }
   }
 }


### PR DESCRIPTION
Should allow projects including Arizona Bootstrap via composer to reference a `2.*` version rather than `dev-main`.