### PR TITLE
Replay the repository_dispatch payload on az_quickstart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,35 @@ jobs:
           release_name: "v${{ github.event.client_payload.version }}"
           draft: false
           prerelease: false #${{ contains(env.AZ_VERSION, '-alpha') }}
+
+      - run: echo "${{ toJSON(github.event.client_payload) }}" > az_bootstrap_release.json
+      - name: Upload az_bootstrap_release.json
+        uses: actions/upload-artifact@v1
+        with:
+          name: artifact
+          path: ./az_bootstrap_release.json
+
+  dispatch:
+    needs: release
+    strategy:
+      matrix:
+        repo:
+          - az-digital/az_quickstart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download az_bootstrap_release.json
+        uses: actions/download-artifact@v1
+        with:
+          name: artifact
+
+      - name: Load event
+        run: |
+          echo "::set-env name=CLIENT_PAYLOAD::$(cat az_bootstrap_release.json | jq -c)"
+
+      - name: Notify dependencies
+        uses: peter-evans/repository-dispatch@1708dda5703a768a0fb0ef6a7a03a0c3805ebc59
+        with:
+          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
+          repository: ${{ matrix.repo }}
+          event-type: az_bootstrap_release
+          client-payload: ${{ env.CLIENT_PAYLOAD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,13 +49,6 @@ jobs:
           draft: false
           prerelease: false #${{ contains(env.AZ_VERSION, '-alpha') }}
 
-      - run: echo "${{ toJSON(github.event.client_payload) }}" > az_bootstrap_release.json
-      - name: Upload az_bootstrap_release.json
-        uses: actions/upload-artifact@v1
-        with:
-          name: artifact
-          path: ./az_bootstrap_release.json
-
   dispatch:
     needs: release
     strategy:
@@ -64,20 +57,10 @@ jobs:
           - az-digital/az_quickstart
     runs-on: ubuntu-latest
     steps:
-      - name: Download az_bootstrap_release.json
-        uses: actions/download-artifact@v1
-        with:
-          name: artifact
-
-      - name: Load version from event
-        run: |
-          version=$(jq -r '.version' artifact/az_bootstrap_release.json)
-          echo "::set-env name=AZ_VERSION::${version}"
-
       - name: Notify dependencies
         uses: peter-evans/repository-dispatch@1708dda5703a768a0fb0ef6a7a03a0c3805ebc59
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: ${{ matrix.repo }}
           event-type: az_bootstrap_release
-          client-payload: '{"version": "${{ env.AZ_VERSION }}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{"version": "${{ github.event.client_payload.version }}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,9 +69,10 @@ jobs:
         with:
           name: artifact
 
-      - name: Load event
+      - name: Load version from event
         run: |
-          echo "::set-env name=CLIENT_PAYLOAD::$(cat az_bootstrap_release.json | jq -c)"
+          version=$(jq -r '.version' artifact/az_bootstrap_release.json)
+          echo "::set-env name=AZ_VERSION::${version}"
 
       - name: Notify dependencies
         uses: peter-evans/repository-dispatch@1708dda5703a768a0fb0ef6a7a03a0c3805ebc59
@@ -79,4 +80,4 @@ jobs:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: ${{ matrix.repo }}
           event-type: az_bootstrap_release
-          client-payload: ${{ env.CLIENT_PAYLOAD }}
+          client-payload: '{"version": "${{ env.AZ_VERSION }}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,10 +57,14 @@ jobs:
           - az-digital/az_quickstart
     runs-on: ubuntu-latest
     steps:
+      - name: Get release data
+        run: |
+          sha=$(git rev-parse HEAD)
+          echo "::set-env name=RELEASE_SHA::${sha}"
       - name: Notify dependencies
         uses: peter-evans/repository-dispatch@1708dda5703a768a0fb0ef6a7a03a0c3805ebc59
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: ${{ matrix.repo }}
           event-type: az_bootstrap_release
-          client-payload: '{"version": "${{ github.event.client_payload.version }}", "ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'
+          client-payload: '{"version": "${{ github.event.client_payload.version }}", "sha": "${{ env.RELEASE_SHA }}"}'


### PR DESCRIPTION
This addition replays the same notification that it received against az_quickstart. This may or may not be desirable as the `ref` and `sha` it includes are from `arizona-bootstrap` and not `arizona-bootstrap-packagist`

Closes #10
