### PR TITLE
arizona-digital/arizona-bootstrap#567: Use bot user token instead of old SSH key to push changes back to repo.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,15 +10,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
-          ssh-key: ${{ secrets.SELF_DEPLOY_KEY }}
+          token: ${{ secrets.REPO_DISPATCH_TOKEN }}
 
       - name: Build variables
         run: echo "AZ_BOOTSTRAP_CLONE_DIR=arizona-bootstrap" >> ${GITHUB_ENV}
 
       - name: Get new updates from arizona-bootstrap
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: az-digital/arizona-bootstrap
           path: ${{ env.AZ_BOOTSTRAP_CLONE_DIR }}


### PR DESCRIPTION
Also updates all instances of actions/checkout with v3.