### PR TITLE
Closes #16: Tag correct revision upon release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,7 @@ jobs:
           done
           git commit -m "Arizona Bootstrap updates for ${{ github.event.client_payload.version }}"
           git push
+          echo "RELEASE_SHA=$(git rev-parse HEAD)" >> ${GITHUB_ENV}
 
       - name: Create Release
         id: create_release
@@ -43,6 +44,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          commitish: "${{ env.RELEASE_SHA }}"
           tag_name: "v${{ github.event.client_payload.version }}"
           release_name: "v${{ github.event.client_payload.version }}"
           draft: false


### PR DESCRIPTION
Fixes issue with release GH action in this repo that is triggered any time an Arizona Bootstrap release is created.  Currently the workflow is tagging the incorrect revision when propagating the tag from Arizona Bootstrap.


Closes #16.