### PR TITLE
az-digital/az_quickstart#690: Allow this package to replace twbs/bootstrap composer package.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
   "require": {
       "composer/installers": "*"
   },
+  "replace": {
+      "twbs/bootstrap": "*"
+  },
   "extra": {
       "branch-alias": {
           "dev-main": "2.x-dev"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
       "composer/installers": "*"
   },
   "replace": {
-      "twbs/bootstrap": "*"
+      "twbs/bootstrap": "^4"
   },
   "extra": {
       "branch-alias": {


### PR DESCRIPTION
(copied from https://github.com/az-digital/az_quickstart/pull/2096):

In the issue discussion on https://github.com/az-digital/az_quickstart/issues/690, @joshuasosa provided the good suggestion to try setting az_barrio to have composer settings to be replacement of twbs/boostrap as a means of causing bootstrap_barrio to not download the bootstrap source as it normally does. This might be a good means of addressing [our open barrio issue](https://www.drupal.org/project/bootstrap_barrio/issues/3138347) on our end.

Related issues
https://github.com/az-digital/az_quickstart/issues/690