### PR TITLE
Integrate with new 2.x workflow for arizona bootstrap.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,4 +70,4 @@ jobs:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
           repository: ${{ matrix.repo }}
           event-type: az_bootstrap_release
-          client-payload: '{"version": "${{ github.event.client_payload.version }}", "sha": "${{ env.RELEASE_SHA }}"}'
+          client-payload: '{"version": "${{ github.event.client_payload.version  }}", "sha": "${{ env.RELEASE_SHA }}", "branch": "${{ github.event.client_payload.branch }}" }'


### PR DESCRIPTION
Downstream workflows depend on the branch variable.

See https://github.com/az-digital/az_quickstart/blob/main/.github/workflows/arizona-bootstrap-release.yml#L9



Basically, arizona bootstrap pings this repo, and this repo pings az_quickstart

https://github.com/az-digital/arizona-bootstrap/actions/runs/4147439130/jobs/7174369977
then
https://github.com/az-digital/arizona-bootstrap-packagist/actions/runs/4147462868/jobs/7174376172
then
https://github.com/az-digital/az_quickstart/actions/runs/4147465959