### PR TITLE
Closes #23 Check out the 2.x branch when a release from 2.x occurs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           token: ${{ secrets.REPO_DISPATCH_TOKEN }}
+          ref: ${{ github.event.client_payload.branch }}
 
       - name: Build variables
         run: echo "AZ_BOOTSTRAP_CLONE_DIR=arizona-bootstrap" >> ${GITHUB_ENV}


### PR DESCRIPTION

What this does:
1. In this github action, it checks out the branch of this repo that the new release is destined for.
2. checks out the SHA1 from the source repo release to replace the files in this repo on the correct branch.


See https://github.com/az-digital/arizona-bootstrap/blob/main/.github/workflows/release.yml#L112
Closes #23

This can be merged at any time before the next arizona bootstrap release.