### PR TITLE
Close #33 Add Bootstrap 5 support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
       "composer/installers": "*"
   },
   "replace": {
-      "twbs/bootstrap": "^4"
+      "twbs/bootstrap": "^4 || ^5"
   },
   "extra": {
       "branch-alias": {


### PR DESCRIPTION
This PR makes it possible to use this package as a replacement for the twbs/bootstrap packagist library.
This would unblock this PR on the Quickstart Repository: https://github.com/az-digital/az_quickstart/pull/4306